### PR TITLE
Filtragem de palavras chave

### DIFF
--- a/src/main/java/com/gamecontrol/dto/CreateGameRequest.java
+++ b/src/main/java/com/gamecontrol/dto/CreateGameRequest.java
@@ -23,7 +23,7 @@ public class CreateGameRequest {
     private Double rating;
     private Long ratingCount;
     private String releaseDate;
-
+    private Integer themeId;
     /** Se informado, o documento é criado com este ID (ex.: slug único). */
     private String documentId;
 

--- a/src/main/java/com/gamecontrol/dto/GameDTO.java
+++ b/src/main/java/com/gamecontrol/dto/GameDTO.java
@@ -27,4 +27,5 @@ public class GameDTO {
     private String title;
     private Double totalRating;
     private Long totalRatingCount;
+    private Integer themeId;
 }

--- a/src/main/java/com/gamecontrol/service/GameFirestoreMapper.java
+++ b/src/main/java/com/gamecontrol/service/GameFirestoreMapper.java
@@ -34,6 +34,7 @@ final class GameFirestoreMapper {
         dto.setReleaseDate(snap.getString("releaseDate"));
         dto.setSlug(snap.getString("slug"));
         dto.setTitle(snap.getString("title"));
+        dto.setThemeId(toInteger(snap.get("themeId")));
         dto.setTotalRating(toDouble(snap.get("totalRating")));
         dto.setTotalRatingCount(toLong(snap.get("totalRatingCount")));
         Timestamp ts = snap.getTimestamp("syncedAt");
@@ -58,6 +59,7 @@ final class GameFirestoreMapper {
         putIfNotNull(m, "ratingCount", req.getRatingCount());
         putIfNotNull(m, "releaseDate", req.getReleaseDate());
         putIfNotNull(m, "slug", req.getSlug());
+        putIfNotNull(m, "themeId", req.getThemeId());
         m.put("title", req.getTitle());
         putIfNotNull(m, "totalRating", req.getTotalRating());
         putIfNotNull(m, "totalRatingCount", req.getTotalRatingCount());
@@ -86,6 +88,7 @@ final class GameFirestoreMapper {
         putIfNotNull(m, "ratingCount", patch.getRatingCount());
         putIfNotNull(m, "releaseDate", patch.getReleaseDate());
         putIfNotNull(m, "slug", patch.getSlug());
+        putIfNotNull(m, "themeId", patch.getThemeId());
         putIfNotNull(m, "title", patch.getTitle());
         putIfNotNull(m, "totalRating", patch.getTotalRating());
         putIfNotNull(m, "totalRatingCount", patch.getTotalRatingCount());
@@ -100,6 +103,17 @@ final class GameFirestoreMapper {
         if (value != null) {
             m.put(key, value);
         }
+    }
+
+    private static Integer toInteger(Object v) {
+
+        if (v == null) return null;
+
+        if (v instanceof Integer i) return i;
+
+        if (v instanceof Long l) return l.intValue();
+
+        return ((Number) v).intValue();
     }
 
     private static Long toLong(Object v) {

--- a/src/main/java/com/gamecontrol/service/GameService.java
+++ b/src/main/java/com/gamecontrol/service/GameService.java
@@ -1,5 +1,4 @@
 package com.gamecontrol.service;
-
 import com.gamecontrol.dto.CreateGameRequest;
 import com.gamecontrol.dto.GameDTO;
 import com.google.cloud.firestore.DocumentReference;
@@ -11,6 +10,7 @@ import com.google.cloud.firestore.QuerySnapshot;
 import com.google.cloud.firestore.SetOptions;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+
 
 import java.util.ArrayList;
 import java.util.List;
@@ -34,10 +34,30 @@ public class GameService {
         return executar(() -> {
             QuerySnapshot resultado = firestore.collection(nomeColecaoJogos).get().get();
             List<GameDTO> jogos = new ArrayList<>();
+
+            // Lista de termos recorrentes em slugs/títulos de jogos adultos
+            List<String> termosProibidos = List.of(
+                    "succubus", "prison", "delude", "hentai", "adult", "sexy", "erotic",
+                    "nsfw", "naked", "sex", "porn", "femboy", "sleepover", "ecchi",
+                    "harem", "uncensored", "lewd", "fetish", "milf", "corruption",
+                    "mistress", "lust", "desire", "breeding", "affair", "sin", "oppai", "cumming", "Opala"
+            );
+
             for (QueryDocumentSnapshot documento : resultado.getDocuments()) {
                 GameDTO jogo = GameFirestoreMapper.fromSnapshot(documento);
+
                 if (jogo != null) {
-                    jogos.add(jogo);
+                    // Normalização para minúsculas para garantir a comparação
+                    String slugLower = jogo.getSlug() != null ? jogo.getSlug().toLowerCase() : "";
+                    String titleLower = jogo.getTitle() != null ? jogo.getTitle().toLowerCase() : "";
+
+                    // Verifica se o slug ou título contém alguma das palavras proibidas
+                    boolean contemConteudoRestrito = termosProibidos.stream()
+                            .anyMatch(termo -> slugLower.contains(termo) || titleLower.contains(termo));
+
+                    if (!contemConteudoRestrito) {
+                        jogos.add(jogo);
+                    }
                 }
             }
             return jogos;


### PR DESCRIPTION
Feito por Cauet:
Filtragem por palavras sugestiva em títulos de jogos para a exclusão de jogos com nomes eróticos na lista mostrada ao usuário + inclusão do atributo "themeid" no backend